### PR TITLE
Add arguments to `setup`

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,5 +2,9 @@ from setuptools import setup
 
 setup(name='gym_gridworld',
       version='0.0.1',
+      author='André Teixeira',
+      description='A variation of the OpenAI gym Frozen Lake, mimicking the minimalistic GridWorld',
+      url='https://github.com/andremht/gym_gridworld',
+      packages=setuptools.find_packages(),
       install_requires=['gym>=0.2.3']
 )


### PR DESCRIPTION
I had problems with installing the package without the additional `packages` argument. I added some other metadata as well, similar to https://github.com/magni84/gym_bandits/blob/master/setup.py. In general, I guess it would be good to add some license as well.