### PR TITLE
Add import statement

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,3 +1,4 @@
+import setuptools
 from setuptools import setup
 
 setup(name='gym_gridworld',


### PR DESCRIPTION
Just noticed that I forgot an import statement in my PR. I'm actually a bit surprised that it worked nevertheless, maybe it's (usually) available anyway during package installation. In any case, it seems more correct to import `setuptools`.